### PR TITLE
Feature/request handler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 *.iml
-.gradle
 /local.properties
 /.idea/workspace.xml
 /.idea/libraries
@@ -9,3 +8,11 @@
 .idea
 .idea/*
 /out
+
+
+#Gradle files
+.gradle
+gradle-app.setting
+reader/gradle/*
+reader/gradlew
+reader/gradlew.bat

--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+We are crypto bot
+
+we will update you on bitcoin price if you ask us gently

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 We are crypto bot
 
 we will update you on bitcoin price if you ask us gently
+
+bot api https://github.com/pengrad/java-telegram-bot-api

--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,7 @@ repositories {
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib-jre8:$kotlin_version"
     compile 'com.github.pengrad:java-telegram-bot-api:3.3.0'
+    compile "org.jetbrains.kotlin:kotlin-reflect:1.1.4-3"
 }
 
 compileKotlin {

--- a/src/main/kotlin/ru/justd/cryptobot/Main.kt
+++ b/src/main/kotlin/ru/justd/cryptobot/Main.kt
@@ -32,43 +32,44 @@ private fun processUpdate(update: Update) {
         entities?.forEach {
             when (it.type()) {
                 bot_command -> handleBotCommand(message)
-                mention,
-                hashtag,
-                url,
-                email,
-                bold,
-                italic,
-                code,
-                pre,
-                text_link,
-                text_mention -> println("message type not supported ${it.type()}")
+//                mention,
+//                hashtag,
+//                url,
+//                email,
+//                bold,
+//                italic,
+//                code,
+//                pre,
+//                text_link,
+//                text_mention -> println("message type not supported ${it.type()}")
                 else -> println("else message type not supported ${it.type()}")
             }
         }
-    } else {
-        if (isBotAddedToChannel(message)) {
-            sendMessage(message.chat().id(), BotResponse.ABOUT)
-            sendMessage(message.chat().id(), BotResponse.HELP)
-        } else {
-            println("message not handled: $message")
-        }
     }
+//    else {
+//        if (isBotAddedToChannel(message)) {
+//            sendMessage(message.chat().pattern(), BotResponse.ABOUT)
+//            sendMessage(message.chat().pattern(), BotResponse.HELP)
+//        } else {
+//            println("message not handled: $message")
+//        }
+//    }
 }
 
 private fun isBotAddedToChannel(message: Message) =
         message.newChatMembers()?.find { user -> user.isBot && user.username() == "CryptAdviserBot" } != null
 
 fun handleBotCommand(message: Message) {
-    val command = message.text().replace("/", "")
+    val command = message.text()
     val chatId = message.chat().id()
 
-    sendMessage(chatId, findResponseFor(command))
+    sendMessage(chatId, RequestHandler.valueOf(command))
 }
 
-fun sendMessage(chatId: Long, response: BotResponse) {
+fun sendMessage(chatId: Long, requestHandler: RequestHandler) {
     println("send message...")
     bot.execute(
-            SendMessage(chatId, response.responseMessage),
+            SendMessage(chatId, requestHandler.responseMessage()),
             object : Callback<SendMessage, SendResponse> {
                 override fun onResponse(request: SendMessage?, response: SendResponse?) {
                     println("response")
@@ -79,30 +80,4 @@ fun sendMessage(chatId: Long, response: BotResponse) {
                 }
 
             })
-}
-
-fun findResponseFor(command: String) = BotResponse.values().find { it.command == command } ?: BotResponse.UNSUPPORTED_REQUEST
-
-//fun replyTo(command: String) = BotResponse.values().find { it.command == command }?.responseMessage
-
-enum class BotResponse(val command: String?, val responseMessage: String) { //todo use sealed class to differentiate the functionality
-
-    /**
-     * Information about available commands
-     */
-    HELP("help", "no help for you beach"),
-
-    /**
-     * Update for your subscriptions
-     */
-    UPDATE("update", "your update"),
-
-    /**
-     * Information of current version of the bot
-     */
-    ABOUT("about", "v.1, to see list of supported commands type /help"), //todo retrieve version from build.gradle
-
-    UNSUPPORTED_REQUEST(null, "command not recognized");
-
-
 }

--- a/src/main/kotlin/ru/justd/cryptobot/Main.kt
+++ b/src/main/kotlin/ru/justd/cryptobot/Main.kt
@@ -25,51 +25,37 @@ fun main(args: Array<String>) {
 
 private fun processUpdate(update: Update) {
     val message = update.message()
-    println("message ${message?.entities()?.get(0)?.type() ?: ""}: ${message.text()}")
+    println("message ${message?.entities()?.get(0)?.type() ?: ""}: ${message?.text() ?: "null"}")
 
     val entities = message.entities()
     if (!entities.isEmpty()) {
         entities?.forEach {
             when (it.type()) {
                 bot_command -> handleBotCommand(message)
-//                mention,
-//                hashtag,
-//                url,
-//                email,
-//                bold,
-//                italic,
-//                code,
-//                pre,
-//                text_link,
-//                text_mention -> println("message type not supported ${it.type()}")
                 else -> println("else message type not supported ${it.type()}")
             }
         }
     }
-//    else {
-//        if (isBotAddedToChannel(message)) {
-//            sendMessage(message.chat().pattern(), BotResponse.ABOUT)
-//            sendMessage(message.chat().pattern(), BotResponse.HELP)
-//        } else {
-//            println("message not handled: $message")
-//        }
-//    }
+
+    if (isBotAddedToChannel(message)) {
+        sendMessage(message.chat().id(), RequestHandler.About.responseMessage())
+        sendMessage(message.chat().id(), RequestHandler.Help.responseMessage())
+    }
 }
 
+//todo is there's better way to do it?
 private fun isBotAddedToChannel(message: Message) =
         message.newChatMembers()?.find { user -> user.isBot && user.username() == "CryptAdviserBot" } != null
 
 fun handleBotCommand(message: Message) {
-    val command = message.text()
-    val chatId = message.chat().id()
-
-    sendMessage(chatId, RequestHandler.valueOf(command))
+    val requestHandler = RequestHandler.valueOf(message.text())
+    sendMessage(message.chat().id(), requestHandler.responseMessage())
 }
 
-fun sendMessage(chatId: Long, requestHandler: RequestHandler) {
+fun sendMessage(chatId: Long, outcomingMessage: String) {
     println("send message...")
     bot.execute(
-            SendMessage(chatId, requestHandler.responseMessage()),
+            SendMessage(chatId, outcomingMessage),
             object : Callback<SendMessage, SendResponse> {
                 override fun onResponse(request: SendMessage?, response: SendResponse?) {
                     println("response")

--- a/src/main/kotlin/ru/justd/cryptobot/RequestHandler.kt
+++ b/src/main/kotlin/ru/justd/cryptobot/RequestHandler.kt
@@ -1,0 +1,42 @@
+package ru.justd.cryptobot
+
+import kotlin.reflect.full.isSubclassOf
+
+sealed class RequestHandler(val pattern: String?) {
+
+    object Help : RequestHandler("/help") {
+        override fun responseMessage() = "ain't no help for you, doug"
+    }
+
+    object Update : RequestHandler("/update") {
+        override fun responseMessage() = "ain't no update for you, doug"
+    }
+
+    object About : RequestHandler("/about") {
+        override fun responseMessage() = "ain't no about for you, doug"
+    }
+
+    object Price : RequestHandler("\\/price [A-Z,a-z]{3}\\z") {
+        override fun responseMessage() = "ain't no price for you, doug"
+    }
+
+    object UnsupportedRequest : RequestHandler(null) {
+        override fun responseMessage() = "request is not supported"
+    }
+
+    abstract fun responseMessage(): String
+
+    companion object {
+        private val map = RequestHandler::class.nestedClasses
+                .filter { klass -> klass.isSubclassOf(RequestHandler::class) }
+                .map { klass -> klass.objectInstance }
+                .filterIsInstance<RequestHandler>()
+                .associateBy { it.pattern }
+
+        fun valueOf(value: String) = map[value] ?: UnsupportedRequest
+
+        fun values() = map.values.toTypedArray()
+
+        fun findHandler(command: String) : RequestHandler = values().find { it.pattern != null && Regex(it.pattern).matches(command) } ?: UnsupportedRequest
+    }
+}

--- a/src/test/kotlin/ru/justd/cryptobot/RequestHandlerTest.kt
+++ b/src/test/kotlin/ru/justd/cryptobot/RequestHandlerTest.kt
@@ -1,0 +1,21 @@
+package ru.justd.cryptobot
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import ru.justd.cryptobot.RequestHandler.Companion.findHandler
+import ru.justd.cryptobot.RequestHandler.*
+
+internal class RequestHandlerTest{
+
+    @Test
+    fun testFindPriceRequestHandler(){
+        assertTrue(findHandler("/price") == UnsupportedRequest)
+        assertTrue(findHandler("/price Bitcoin") == UnsupportedRequest)
+        assertTrue(findHandler("/price 123") == UnsupportedRequest)
+
+        assertTrue(findHandler("/price hui") == Price) //todo add list of supported cryptos or determine it dynamically
+        assertTrue(findHandler("/price BTC") == Price)
+        assertTrue(findHandler("/price ETH") == Price)
+    }
+
+}


### PR DESCRIPTION
replace `enum BotResponse` with `sealed class RequestHandler`

add  compile "org.jetbrains.kotlin:kotlin-reflect:1.1.4-3" to be able call sealed class `RequestHandler.valueOf` like for enum

map user messages to RequestHandler implementation with regexp patterns (+ tests for this)
